### PR TITLE
add logical vector of required columns as attribute of table

### DIFF
--- a/R/check_data_tables.R
+++ b/R/check_data_tables.R
@@ -59,7 +59,8 @@ check_table_names <- function(tables, model) {
 #'     and model. Each table element is \code{NULL} if columns in \code{tables} matches \code{model}, 
 #'     or a list:
 #'     \itemize{
-#'         \item{missing_columns: }{Vector of columns in \code{model} but not in \code{tables}}
+#'         \item{missing_required_columns: }{Vector of required columns in \code{model} but not in \code{tables}}
+#'         \item{missing_optional_columns: }{Vector of optional columns in \code{model} but not in \code{tables}}
 #'         \item{extra_columns: }{Vector of columns in \code{tables} but not in \code{model}}
 #'     }
 #'     
@@ -70,7 +71,10 @@ check_column_names <- function(tables, model) {
         if (setequal(names(tables[[t]]), names(model[[t]]))) {
             return(NULL)
         } else {
-            return(list(missing_columns=setdiff(names(model[[t]]), names(tables[[t]])),
+            required <- names(model[[t]])[attr(model[[t]], "required")]
+            optional <- names(model[[t]])[!attr(model[[t]], "required")]
+            return(list(missing_required_columns=setdiff(required, names(tables[[t]])),
+                        missing_optional_columns=setdiff(optional, names(tables[[t]])),
                         extra_columns=setdiff(names(tables[[t]]), names(model[[t]]))))
         }
     })

--- a/R/import_data_model.R
+++ b/R/import_data_model.R
@@ -11,7 +11,8 @@
 #'   \item{entity: }{"Table" or "enum"}
 #'   \item{table: }{table or enum name}
 #'   \item{column: }{column name within table}
-#'   \item{type: }{"varchar", "bool", "int", "float", "date", "datetime", or name of enum}
+#'   \item{type: }{"string", "boolean, "integer", "float", "date", "dateTime", or name of enum}
+#'   \item{required: }{logical where TRUE indicates the column is required}
 #'   \item{pk: }{logical where TRUE indicates the column is a primary key, 
 #'     other values may be FALSE or missing}
 #'   \item{ref: }{Reference string following the 
@@ -74,7 +75,9 @@ tsv_to_dm <- function(tsv) {
             }
         })
         names(tab) <- this$column
-        return(as_tibble(tab))
+        tib <- as_tibble(tab)
+        attr(tib, "required") <- ifelse(is.na(this$required), FALSE, this$required)
+        return(tib)
     })
     names(table_list) <- tables
     

--- a/tests/testthat/test_check.R
+++ b/tests/testthat/test_check.R
@@ -27,9 +27,12 @@ test_that("check column names", {
     expect_equal(check_column_names(tables, model), lapply(tables, function(x) NULL))
     
     tables$sample$sample_id <- NULL
+    tables$sample$age_at_sample_collection <- NULL
     tables$sample$foo <- "a"
     expect_equal(check_column_names(tables, model)$sample,
-                 list(missing_columns="sample_id", extra_columns="foo"))
+                 list(missing_required_columns="sample_id",
+                      missing_optional_columns="age_at_sample_collection",
+                      extra_columns="foo"))
 })
 
 


### PR DESCRIPTION
The 'dm' object does not have a way to record which columns are
required, but we can set attributes on each tibble in the data
model. Fixes #5 