### PR TITLE
remove block iteration in anvil_import_table

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: AnvilDataModels
-Version: 0.2.8
+Version: 0.2.9
 Type: Package
 Title: Utilities for AnVIL data models
 Description: Utilities for AnVIL data models.

--- a/R/anvil_import.R
+++ b/R/anvil_import.R
@@ -25,30 +25,17 @@
 #' @param overwrite Logical for whether to overwrite data for existing rows
 #' @param namespace AnVIL workspace namespace
 #' @param name AnVIL workspace name
-#' @param n_max maximum number of rows to import at once. Due to AnVIL's restrictions on size of imports, if \code{nrow(table) > n_max}, the import will happen in blocks.
 #' 
 #' @import AnVIL
 #' @export
 anvil_import_table <- function(table, table_name, model, overwrite=FALSE,
                                namespace = avworkspace_namespace(),
-                               name = avworkspace_name(),
-                               n_max = 100000) {
+                               name = avworkspace_name()) {
     # add entity id first, so we can compare to anvil
     table <- add_entity_id(table, table_name, model)
     
-    # can't import >100k rows at once
-    n <- nrow(table)
-    if (n <= n_max) {
-        .anvil_import_table(table, table_name, overwrite,
-                            namespace=namespace, name=name)
-    } else {
-        blocks <- ((1:n) - 1) %/% n_max
-        for (i in unique(blocks)) {
-            xtable <- table[blocks == i,]
-            .anvil_import_table(xtable, table_name, overwrite,
-                                namespace=namespace, name=name)
-        }
-    }
+    .anvil_import_table(table, table_name, overwrite,
+                        namespace=namespace, name=name)
 }
 
 

--- a/man/anvil_import.Rd
+++ b/man/anvil_import.Rd
@@ -15,8 +15,7 @@ anvil_import_table(
   model,
   overwrite = FALSE,
   namespace = avworkspace_namespace(),
-  name = avworkspace_name(),
-  n_max = 1e+05
+  name = avworkspace_name()
 )
 
 anvil_import_set(
@@ -51,8 +50,6 @@ anvil_import_tables(
 \item{namespace}{AnVIL workspace namespace}
 
 \item{name}{AnVIL workspace name}
-
-\item{n_max}{maximum number of rows to import at once. Due to AnVIL's restrictions on size of imports, if \code{nrow(table) > n_max}, the import will happen in blocks.}
 
 \item{set_table}{set table returned by \code{\link{avtable}}}
 

--- a/tests/testthat/report_test.R
+++ b/tests/testthat/report_test.R
@@ -44,7 +44,7 @@ tables$sample$tissue_source <- NULL
 tables$sample$hat <- "a"
 tables$sample$shoe <- "b"
 tables$sample$age_at_sample_collection <- "a"
-tables$subject$reported_sex <- "A"
+tables$subject$reported_sex <- sample(LETTERS, nrow(tables$subject), replace=TRUE)
 tables$sample$sample_id[1] <- tables$sample$sample_id[2]
 tables$sample$date_of_sample_processing[1] <- "a"
 tables$subject <- filter(tables$subject, subject_id != "subject1")


### PR DESCRIPTION
The Bioconductor AnVIL package v 1.13.1 implements blocks in avtable_import and avtable_import set, so remove blocks from the wrapper function.