### PR TITLE
improve wait_for_upload function

### DIFF
--- a/R/anvil_import.R
+++ b/R/anvil_import.R
@@ -190,7 +190,7 @@ add_entity_id <- function(table, table_name, model) {
     while (!all(js$status == "Done")) {
         if (any(js$status %in% c("Failed", "Error"))) {
             print(job_status)
-            print(na.omit(js$message))
+            print(setdiff(js$message, NA))
             stop("Import failed")
         }
         Sys.sleep(60)

--- a/R/anvil_import.R
+++ b/R/anvil_import.R
@@ -186,12 +186,11 @@ add_entity_id <- function(table, table_name, model) {
 
 .wait_for_upload <- function(job_status, namespace, name) {
     if (length(job_status) == 0) return(job_status)
-    js <- bind_rows(job_status)$status
-    jm <- bind_rows(job_status)$message
-    while (!all(js == "Done")) {
-        if (any(js %in% c("Failed", "Error"))) {
+    js <- bind_rows(job_status)
+    while (!all(js$status == "Done")) {
+        if (any(js$status %in% c("Failed", "Error"))) {
             print(job_status)
-            print(na.omit(jm))
+            print(na.omit(js$message))
             stop("Import failed")
         }
         Sys.sleep(60)
@@ -202,7 +201,7 @@ add_entity_id <- function(table, table_name, model) {
                                                      namespace=namespace, 
                                                      name=name)
         }
-        js <- bind_rows(job_status)$status
+        js <- bind_rows(job_status)
     }
     job_status
 }

--- a/R/anvil_import.R
+++ b/R/anvil_import.R
@@ -190,6 +190,7 @@ add_entity_id <- function(table, table_name, model) {
     while (!all(js == "Done")) {
         if (any(js %in% c("Failed", "Error"))) {
             print(job_status)
+            print(na.omit(js$message))
             stop("Import failed")
         }
         Sys.sleep(60)

--- a/R/anvil_import.R
+++ b/R/anvil_import.R
@@ -187,10 +187,11 @@ add_entity_id <- function(table, table_name, model) {
 .wait_for_upload <- function(job_status, namespace, name) {
     if (length(job_status) == 0) return(job_status)
     js <- bind_rows(job_status)$status
+    jm <- bind_rows(job_status)$message
     while (!all(js == "Done")) {
         if (any(js %in% c("Failed", "Error"))) {
             print(job_status)
-            print(na.omit(js$message))
+            print(na.omit(jm))
             stop("Import failed")
         }
         Sys.sleep(60)

--- a/man/anvil_import.Rd
+++ b/man/anvil_import.Rd
@@ -35,7 +35,8 @@ anvil_import_tables(
   model = NULL,
   overwrite = FALSE,
   namespace = avworkspace_namespace(),
-  name = avworkspace_name()
+  name = avworkspace_name(),
+  timeout = 3600
 )
 }
 \arguments{
@@ -54,6 +55,8 @@ anvil_import_tables(
 \item{set_table}{set table returned by \code{\link{avtable}}}
 
 \item{tables}{Named list of tables to import}
+
+\item{timeout}{Number of seconds to wait for import to complete before timing out}
 }
 \value{
 \code{create_set_all} returns a tibble with one set, 'all',

--- a/tests/testthat/workspace_test.R
+++ b/tests/testthat/workspace_test.R
@@ -113,9 +113,9 @@ test_that("set", {
 test_that("upload error", {
     json <- system.file("extdata", "data_model.json", package="AnvilDataModels")
     model <- json_to_dm(json)
-    table_name <- "subject"
-    file <- system.file("extdata", paste0(table_name, ".tsv"), package="AnvilDataModels")
-    table <- read_data_tables(file, table_name, quiet=TRUE)
-    table$subject$subject_id[1] <- "a+b" # illegal character for primary key
-    status <- anvil_import_tables(table, model, overwrite=TRUE)
+    table_names <- c("subject", "sample")
+    files <- system.file("extdata", paste0(table_names, ".tsv"), package="AnvilDataModels")
+    tables <- read_data_tables(files, table_names, quiet=TRUE)
+    tables$subject$subject_id[1] <- "a+b" # illegal character for primary key
+    expect_error(anvil_import_tables(tables, model, overwrite=TRUE), "Import failed")
 })

--- a/tests/testthat/workspace_test.R
+++ b/tests/testthat/workspace_test.R
@@ -110,12 +110,12 @@ test_that("set", {
   anvil_import_tables(tables, model, overwrite=TRUE)
 })
 
-test_that("import in blocks", {
+test_that("upload error", {
     json <- system.file("extdata", "data_model.json", package="AnvilDataModels")
     model <- json_to_dm(json)
     table_name <- "subject"
     file <- system.file("extdata", paste0(table_name, ".tsv"), package="AnvilDataModels")
-    tables <- read_data_tables(file, table_name, quiet=TRUE)
-    x <- tables[[table_name]]
-    anvil_import_table(x, table_name, model, overwrite=TRUE, n_max=5)
+    table <- read_data_tables(file, table_name, quiet=TRUE)
+    table$subject$subject_id[1] <- "a+b" # illegal character for primary key
+    status <- anvil_import_tables(table, model, overwrite=TRUE)
 })


### PR DESCRIPTION
.wait_for_upload now prints error messages from AnVIL and times out after an hour (by default, time adjustable) of waiting for jobs to finish uploading.
fixes #24