### PR TITLE
check_valid_entity_id function allows missing entity_id

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: AnvilDataModels
-Version: 0.4.2
+Version: 0.4.3
 Type: Package
 Title: Utilities for AnVIL data models
 Description: Utilities for AnVIL data models.

--- a/R/check_data_tables.R
+++ b/R/check_data_tables.R
@@ -380,12 +380,14 @@ check_bucket_paths_indiv <- function(tables, model) {
 
 
 #' @rdname check_data_tables
+#' @param report_missing_id A logical indicating whether the absence of an entity id is
+#'     regarded as an error.
 #' @return \code{check_valid_entity_id} returns a list of all tables in common between data 
 #'     and model. Each table element is \code{NULL} if the table has a valid AnVIL entity_id, or 
 #'     a string describing the error.
 #'     
 #' @export
-check_valid_entity_id <- function(tables, model) {
+check_valid_entity_id <- function(tables, model, report_missing_id=FALSE) {
     common <- intersect(names(tables), names(model))
     chk <- lapply(common, function(t) {
         entity_id <- intersect(names(tables[[t]]), paste0(t, "_id"))
@@ -399,7 +401,11 @@ check_valid_entity_id <- function(tables, model) {
                 return(NULL)
             }
         } else {
-            return(paste0("Expected column ", t, "_id not found"))
+            if (report_missing_id) {
+                return(paste0("Expected column ", t, "_id not found"))
+            } else {
+                return(NULL)
+            }
         }
     })
     names(chk) <- common

--- a/inst/rmd/data_model_report.Rmd
+++ b/inst/rmd/data_model_report.Rmd
@@ -114,13 +114,13 @@ if (length(chk$missing_keys) == 0) {
 if (any(chk$found_keys$problem != "")) return_value <- FALSE
 ```
 
-AnVIL requires that each table has an entity_id named \<table_name\>_id. Entity ids may only contain alphanumeric characters, underscores, dashes, and periods.
 
 ```{r, message=TRUE}
 chk <- check_valid_entity_id(tables, model)
 res <- parse_column_type_check(chk)
 if (nrow(res) > 0) {
     return_value <- FALSE
+    cat("AnVIL requires that each table has an entity_id named <table_name>_id. Entity ids may only contain alphanumeric characters, underscores, dashes, and periods.")
     knitr::kable(res)
 }
 ```

--- a/man/check_data_tables.Rd
+++ b/man/check_data_tables.Rd
@@ -30,7 +30,7 @@ check_unique(tables, model)
 
 check_bucket_paths(tables, model)
 
-check_valid_entity_id(tables, model)
+check_valid_entity_id(tables, model, report_missing_id = FALSE)
 
 check_primary_keys(tables, model)
 
@@ -50,6 +50,9 @@ parse_column_type_check(chk)
 \item{tables}{Named list of data tables}
 
 \item{model}{\code{\link{dm}} object describing data model}
+
+\item{report_missing_id}{A logical indicating whether the absence of an entity id is
+regarded as an error.}
 
 \item{chk}{output of \code{check_column_names} or \code{check_column_types}}
 }

--- a/tests/testthat/test_check.R
+++ b/tests/testthat/test_check.R
@@ -366,8 +366,10 @@ test_that("check invalid characters", {
     model <- .model()
     tables1 <- tables[c("subject", "sample")]
     expect_equal(check_valid_entity_id(tables1, model), lapply(tables1, function(x) NULL))
-    expect_equal(check_valid_entity_id(tables["phenotype"], model), 
+    expect_equal(check_valid_entity_id(tables["phenotype"], model, report_missing_id=TRUE), 
                  list("phenotype"="Expected column phenotype_id not found"))
+    expect_equal(check_valid_entity_id(tables["phenotype"], model, report_missing_id=FALSE), 
+                 list("phenotype"=NULL))
     
     tables1$sample$sample_id[1:2] <- c("a+b", "a&b")
     expect_equal(check_valid_entity_id(tables1, model)$sample,


### PR DESCRIPTION
Sometimes we want to check tables that are not imported to AnVIL. check_valid_entity_id now has a logical input that controls whether a missing entity_id is reported as an error. If FALSE (the default), only entity_ids that are present are checked for valid characters.