### PR TITLE
allow a conditional column to have some missing values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: AnvilDataModels
-Version: 0.6.2
+Version: 0.7.0
 Type: Package
 Title: Utilities for AnVIL data models
 Description: Utilities for AnVIL data models.

--- a/R/check_data_tables.R
+++ b/R/check_data_tables.R
@@ -96,7 +96,7 @@ check_table_names <- function(tables, model) {
             column <- cond_parsed$column
             value <- cond_parsed$value
             # if condition is met, add to 'required'
-            if (!is.na(value) & any(table[[column]] == value)) {
+            if (!is.na(value) & any(!is.na(table[[column]]) & table[[column]] == value)) {
                 required <- c(required, c)
             }
             # if value is NA, only requirement is column is non-missing

--- a/tests/testthat/test_check.R
+++ b/tests/testthat/test_check.R
@@ -352,6 +352,15 @@ test_that("conditional columns - condition on optional column", {
     expect_setequal(chk$t1$missing_required_columns, character())
     
     dat <- tibble(t1_id=1:2,
+                  condition2=c(NA, NA),
+                  if_condition2=c("a", "b"))
+    chk <- .parse_required_columns(dat, x$t1)
+    expect_setequal(chk$required, c("t1_id"))
+    expect_setequal(chk$optional, c("condition", "if_condition", "condition2", "if_condition2"))
+    chk <- check_column_names(tables=list(t1=dat), model=x)
+    expect_setequal(chk$t1$missing_required_columns, character())
+    
+    dat <- tibble(t1_id=1:2,
                   condition2=c("a", "b"))
     chk <- .parse_required_columns(dat, x$t1)
     expect_setequal(chk$required, c("t1_id", "if_condition2"))


### PR DESCRIPTION
if we condition on an optional column, it may have some missing values, so check for this in the if statement when we parse the condition